### PR TITLE
Postman collection list

### DIFF
--- a/Dock API.postman_collection.json
+++ b/Dock API.postman_collection.json
@@ -198,7 +198,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\"controller\": \"did:dock:5Cde8QWRBxfagcZggvgGNJzDaK4oviq9a3MgApyf7GgwGyau\",\n\"keyType\": \"sr25519\"\n}",
+							"raw": "{\n\"controller\": \"{{did}}\",\n\"keyType\": \"sr25519\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"


### PR DESCRIPTION
I have created a collection list using my own 'DOCK-API-TOKEN'. I can replace it with any of the test token. Main idea here is to check if the well-known requests that can be interested in our users are covered.