### PR TITLE
add external-sites file for managing redirects

### DIFF
--- a/source/redirects/external-sites.json
+++ b/source/redirects/external-sites.json
@@ -1,0 +1,3 @@
+{
+  "/*": "https://docs.dock.io/developer-documentation/dock-api"
+}


### PR DESCRIPTION
Not sure if this going to work, but trying to get gh pages to redirect to the new docs portal (tried doing it via Cloudflare, but we would need to upgrade and buy a new certificate that supports sub-sub-domains to redirect docs.api.dock.io)